### PR TITLE
Fix bug: quickfix window change during quickfix operation (E925)

### DIFF
--- a/lua/qf.lua
+++ b/lua/qf.lua
@@ -170,11 +170,8 @@ function M.reopen_all()
 end
 
 local function set_entry(list, idx)
-  if list == 'c' then
-    fn.setqflist({}, "r", { idx = idx })
-  else
-    fn.setloclist(".", {}, "r", { idx = idx })
-  end
+  local win = util.get_list_win(list)
+  vim.api.nvim_win_set_cursor(win, { idx, 0})
 end
 
 local function current_entry(list)


### PR DESCRIPTION
When pressing enter in the quickfix window, vim would not open the correct location, and shown an error (E925, see there : https://vimhelp.org/quickfix.txt.html). I made this so that the correct line is focused in the quickfix window when enabling follow mode, but without modifying the quickfix window.