### PR TITLE
Config example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Default setup:
 
 ```lua
 require 'qf'.setup {
-  -- Location list configuration
+    -- Location list configuration
     l = {
         auto_close = true, -- Automatically close location/quickfix list if empty
         auto_follow = 'prev', -- Follow current entry, possible values: prev,next,nearest, or false to disable
@@ -146,10 +146,10 @@ require 'qf'.setup {
         relativenumber = false, -- Show relative line numbers in list
         unfocus_close = false, -- Close list when window loses focus
         focus_open = false, -- Auto open list on window focus if it contains items
-      },
-      close_other = false, -- Close location list when quickfix list opens
-      pretty = true, -- Pretty print quickfix lists
-      silent = false, -- Suppress messages like "(1 of 3): *line content*" on jump
+    },
+    close_other = false, -- Close location list when quickfix list opens
+    pretty = true, -- Pretty print quickfix lists
+    silent = false, -- Suppress messages like "(1 of 3): *line content*" on jump
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ require 'qf'.setup {
         relativenumber = false, -- Show relative line numbers in list
         unfocus_close = false, -- Close list when window loses focus
         focus_open = false, -- Auto open list on window focus if it contains items
-      }
+      },
       close_other = false, -- Close location list when quickfix list opens
       pretty = true, -- Pretty print quickfix lists
       silent = false, -- Suppress messages like "(1 of 3): *line content*" on jump


### PR DESCRIPTION
Thanks for interesting plugin.

While I was trying to install and pasted configuration to my configuration for lazy plugin manager, I saw "`Miss symbol`" warning.

So here is a fix for it.

2nd commit is to make indentation consistent.  I used sw=4 since it provided minimum diff.  I actually like sw=2.  So, please let me know if I need to update.