### PR TITLE
feat: add support for :helpgrep and :lhelpgrep

### DIFF
--- a/lua/qf.lua
+++ b/lua/qf.lua
@@ -90,6 +90,8 @@ local post_commands = {
   "cbuffer",
   "cgetbuffer",
   "caddbuffer",
+  "helpgrep",
+  "lhelpgrep",
 }
 
 local function list_post_commands(l)


### PR DESCRIPTION
This PR adds support for the `:helpgrep` and `:lhelpgrep` commands.